### PR TITLE
Update utils.py

### DIFF
--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -537,6 +537,13 @@ def make_relative_url(base, target):
     else:
         depth = ('/' + base.strip('/')).count('/')
         prefix = ''
+        # If the last part of the base path contains a dot, the page will 
+        # render into, for example "404.html" instead of "404/index.html".
+        # Any relative links from it therefore need one less level of depth.
+        if '.' in base.strip('/').split('/')[-1]:
+            depth -= 1
+            if depth == 0:
+                prefix = './'
 
     ends_in_slash = target[-1:] == '/'
     target = posixpath.normpath(posixpath.join(base, target))


### PR DESCRIPTION
Modified def make_relative_url(base, target): so it checks whether the base path belongs to a dotted slug. If so, the depth is reduced by one to point to the target at the right level.

Addresses issue #588 in Github.